### PR TITLE
Update Trove classifiers and add python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     include_package_data=True,
     install_requires=required,
     license='MIT',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -45,6 +46,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     keywords="slack chatbot chat limbo",


### PR DESCRIPTION
Trove classifiers make the supported versions clear on PyPI, and `python_requires` helps pip install the correct version.